### PR TITLE
Install python dependencies for bluesky action

### DIFF
--- a/.github/workflows/bsky.yaml
+++ b/.github/workflows/bsky.yaml
@@ -12,6 +12,14 @@ jobs:
       # You must checkout resources
       - uses: actions/checkout@v3
 
+      - name: Install python dependencies
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: "pip" # caching pip dependencies
+      - run: pip install -r requirements.txt
+        working-directory: ./scripts
+
       - name: Pick a graph
         run: python pick_a_graph.py
         working-directory: ./scripts


### PR DESCRIPTION
Github action was failing because of a lack of numpy. Now point to `requirements.txt` and install dependencies for the scripts, which includes numpy.